### PR TITLE
Fix issue #1: prevent Cloakr auto-activation from external proxy extensions

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -21,7 +21,14 @@ type StartupStorageData = {
   proxyEnabled?: boolean;
 };
 
+type ProxySettingsSnapshot = {
+  enabled: boolean;
+  config: ProxyStatus["config"];
+  controlledByOtherExtension: boolean;
+};
+
 let proxyCredentials: ProxyCredentials | null = null;
+let isApplyingProxy = false;
 const SESSION_CREDENTIALS_KEY = "sessionProxyCredentials";
 
 async function setSessionCredentials(credentials: ProxyCredentials): Promise<void> {
@@ -33,6 +40,11 @@ async function clearSessionCredentials(): Promise<void> {
 }
 
 async function getActiveProxyCredentials(): Promise<ProxyCredentials | null> {
+  const managedProxyActive = await isCloakrManagedProxyActive();
+  if (!managedProxyActive) {
+    return null;
+  }
+
   if (proxyCredentials?.username) {
     return proxyCredentials;
   }
@@ -139,10 +151,7 @@ async function applyProxy(config: ProxyConfig): Promise<void> {
     },
   };
 
-  await chrome.proxy.settings.set({
-    value: proxyConfig,
-    scope: "regular",
-  });
+  isApplyingProxy = true;
 
   const persistedConfig: ProxyConfig = {
     protocol: normalizedProtocol,
@@ -156,11 +165,120 @@ async function applyProxy(config: ProxyConfig): Promise<void> {
     persistedConfig.password = password || "";
   }
 
-  // Persist the active configuration.
+  // Persist first so proxy change listeners do not briefly see a stale disabled state.
   await chrome.storage.local.set({
     proxyConfig: persistedConfig,
     proxyEnabled: true,
   });
+
+  try {
+    await chrome.proxy.settings.set({
+      value: proxyConfig,
+      scope: "regular",
+    });
+  } catch (error) {
+    await chrome.storage.local.set({ proxyEnabled: false });
+    proxyCredentials = null;
+    await clearSessionCredentials();
+    throw error;
+  } finally {
+    isApplyingProxy = false;
+  }
+}
+
+function normalizeProxyConfigForComparison(
+  config:
+    | { protocol?: string; scheme?: string; host?: string; port?: number | string }
+    | null
+    | undefined
+): ProxyStatus["config"] {
+  if (!config) {
+    return null;
+  }
+
+  const rawProtocol =
+    typeof config.protocol === "string"
+      ? config.protocol
+      : typeof config.scheme === "string"
+        ? config.scheme
+        : undefined;
+  const protocol = isProxyProtocol(rawProtocol) ? rawProtocol : undefined;
+  const host = typeof config.host === "string" ? config.host.trim().toLowerCase() : "";
+  const port = normalizePort(config.port);
+
+  if (!protocol || !host || port == null) {
+    return null;
+  }
+
+  return {
+    scheme: protocol,
+    host,
+    port,
+  };
+}
+
+async function readCurrentProxySettings(): Promise<ProxySettingsSnapshot> {
+  return new Promise((resolve) => {
+    chrome.proxy.settings.get(
+      { incognito: false },
+      (details: chrome.types.ChromeSettingGetResult<chrome.proxy.ProxyConfig>) => {
+        const mode = details?.value?.mode;
+        const singleProxy = details?.value?.rules?.singleProxy;
+        const levelOfControl = details?.levelOfControl;
+        resolve({
+          enabled: mode === "fixed_servers",
+          config: mode === "fixed_servers" ? normalizeProxyConfigForComparison(singleProxy) : null,
+          controlledByOtherExtension: levelOfControl === "controlled_by_other_extensions",
+        });
+      }
+    );
+  });
+}
+
+async function isCloakrManagedProxyActive(): Promise<boolean> {
+  if (isApplyingProxy) {
+    return true;
+  }
+
+  const [storageData, currentProxy] = await Promise.all([
+    chrome.storage.local.get(["proxyConfig", "proxyEnabled"]),
+    readCurrentProxySettings(),
+  ]);
+
+  const storedEnabled = Boolean(storageData?.proxyEnabled);
+  const storedConfig = normalizeProxyConfigForComparison(storageData?.proxyConfig as ProxyConfig | undefined);
+
+  if (!storedEnabled || !storedConfig) {
+    proxyCredentials = null;
+    await clearSessionCredentials();
+    return false;
+  }
+
+  if (currentProxy.controlledByOtherExtension) {
+    // Keep saved state intact while another extension controls proxy settings.
+    return false;
+  }
+
+  if (!currentProxy.enabled || !currentProxy.config) {
+    await chrome.storage.local.set({ proxyEnabled: false });
+    proxyCredentials = null;
+    await clearSessionCredentials();
+    return false;
+  }
+
+  const configsMatch =
+    storedConfig.scheme === currentProxy.config.scheme &&
+    storedConfig.host === currentProxy.config.host &&
+    storedConfig.port === currentProxy.config.port;
+
+  if (!configsMatch) {
+    await chrome.storage.local.set({ proxyEnabled: false });
+    proxyCredentials = null;
+    await clearSessionCredentials();
+    return false;
+  }
+
+  return true;
 }
 
 function normalizePort(value: number | string | undefined): number | null {
@@ -195,26 +313,24 @@ async function clearProxy(): Promise<void> {
 }
 
 async function getProxyStatus(): Promise<ProxyStatus> {
-  return new Promise((resolve) => {
-    chrome.proxy.settings.get(
-      { incognito: false },
-      (details: chrome.types.ChromeSettingGetResult<chrome.proxy.ProxyConfig>) => {
-        const singleProxy = details?.value?.rules?.singleProxy;
-        const scheme = isProxyProtocol(singleProxy?.scheme) ? singleProxy?.scheme : undefined;
-        const enabled = details?.value?.mode === "fixed_servers";
-        resolve({
-          enabled,
-          config: singleProxy
-            ? {
-                scheme,
-                host: singleProxy.host,
-                port: singleProxy.port,
-              }
-            : null,
-        });
-      }
-    );
-  });
+  const managedProxyActive = await isCloakrManagedProxyActive();
+  const currentProxy = await readCurrentProxySettings();
+
+  if (!managedProxyActive) {
+    return {
+      enabled: false,
+      config: null,
+      lockReason:
+        currentProxy.controlledByOtherExtension || currentProxy.enabled
+          ? "external_proxy_active"
+          : undefined,
+    };
+  }
+
+  return {
+    enabled: currentProxy.enabled,
+    config: currentProxy.config,
+  };
 }
 
 // Respond to proxy auth challenges.
@@ -258,10 +374,24 @@ try {
   // WXT build-time fake browser does not implement this API.
 }
 
+try {
+  chrome.proxy.settings.onChange.addListener(() => {
+    void isCloakrManagedProxyActive();
+  });
+} catch {
+  // Some environments expose a limited proxy settings API during build.
+}
+
 // Restore the saved proxy on startup.
 chrome.storage.local.get(["proxyConfig", "proxyEnabled"], async (data: StartupStorageData) => {
   const storedConfig = data.proxyConfig as ProxyConfig | undefined;
   if (data.proxyEnabled && storedConfig) {
+    const currentProxy = await readCurrentProxySettings();
+    if (currentProxy.controlledByOtherExtension) {
+      console.warn("[Cloakr] Proxy restore skipped: another extension controls proxy settings");
+      return;
+    }
+
     const hasSavedPassword = Object.prototype.hasOwnProperty.call(storedConfig, "password");
     if (storedConfig.username && !hasSavedPassword) {
       await clearProxy();

--- a/entrypoints/popup/app.ts
+++ b/entrypoints/popup/app.ts
@@ -5,7 +5,10 @@ import {
   disconnectBtn,
   errorMsg,
   hostInput,
+  networkLockMessage,
+  networkLockOverlay,
   passwordInput,
+  popupApp,
   portInput,
   protocolInput,
   protocolLabel,
@@ -42,6 +45,7 @@ export function initPopupApp(): void {
     initProtocolSelect();
     initConfigChangeTracking();
     initEventHandlers();
+    initProxySettingsChangeTracking();
 
     void loadSavedProxies();
     await loadLastConfig();
@@ -223,7 +227,12 @@ async function refreshStatus(): Promise<void> {
     return;
   }
 
-  const { enabled, config } = statusResponse;
+  const { enabled, config, lockReason } = statusResponse;
+
+  if (lockReason === "external_proxy_active") {
+    setNetworkLockedUI();
+    return;
+  }
 
   if (enabled && config) {
     setConnectedUI();
@@ -233,6 +242,7 @@ async function refreshStatus(): Promise<void> {
 }
 
 function setConnectedUI(): void {
+  clearNetworkLockUI();
   isProxyConnected = true;
   hideError();
   statusBadge.textContent = "ON";
@@ -249,6 +259,7 @@ function setConnectedUI(): void {
 }
 
 function setDisconnectedUI(): void {
+  clearNetworkLockUI();
   isProxyConnected = false;
   activeProxySnapshot = null;
   hideError();
@@ -260,7 +271,36 @@ function setDisconnectedUI(): void {
   setDisconnectButtonMode(DISCONNECT_MODE_OFF);
 }
 
+function setNetworkLockedUI(): void {
+  document.body.classList.add("is-network-locked");
+  popupApp.inert = true;
+  popupApp.setAttribute("aria-hidden", "true");
+  networkLockOverlay.hidden = false;
+  const activeElement = document.activeElement as HTMLElement | null;
+  activeElement?.blur();
+  networkLockOverlay.focus();
+  networkLockMessage.textContent =
+    "Another extension is currently controlling network settings. Turn off that extension's proxy to use Cloakr.";
+  isProxyConnected = false;
+  activeProxySnapshot = null;
+  hideError();
+  statusBadge.textContent = "LOCK";
+  statusBadge.className = "status-badge status-error";
+  connectBtn.style.display = "none";
+  disconnectBtn.style.display = "none";
+  retryStatusBtn.style.display = "none";
+}
+
+function clearNetworkLockUI(): void {
+  document.body.classList.remove("is-network-locked");
+  popupApp.inert = false;
+  popupApp.removeAttribute("aria-hidden");
+  networkLockOverlay.hidden = true;
+  networkLockMessage.textContent = "";
+}
+
 function setStatusUnavailableUI(reason?: string): void {
+  clearNetworkLockUI();
   statusBadge.textContent = "ERR";
   statusBadge.className = "status-badge status-error";
   connectBtn.style.display = "none";
@@ -450,6 +490,16 @@ function initConfigChangeTracking(): void {
   rememberPasswordInput.addEventListener("change", () => {
     updateDisconnectButtonMode();
   });
+}
+
+function initProxySettingsChangeTracking(): void {
+  try {
+    chrome.proxy.settings.onChange.addListener(() => {
+      void refreshStatus();
+    });
+  } catch {
+    // Popup still works without live proxy change notifications.
+  }
 }
 
 function hasConfigChangesFromActiveSnapshot(): boolean {

--- a/entrypoints/popup/dom.ts
+++ b/entrypoints/popup/dom.ts
@@ -1,4 +1,5 @@
 export const hostInput = document.getElementById("host") as HTMLInputElement;
+export const popupApp = document.querySelector(".app") as HTMLDivElement;
 export const portInput = document.getElementById("port") as HTMLInputElement;
 export const protocolInput = document.getElementById("protocol") as HTMLInputElement;
 export const protocolSelect = document.getElementById("protocolSelect") as HTMLDivElement;
@@ -17,6 +18,8 @@ export const retryStatusBtn = document.getElementById("retryStatusBtn") as HTMLB
 export const saveBtn = document.getElementById("saveBtn") as HTMLButtonElement;
 export const statusBadge = document.getElementById("statusBadge") as HTMLDivElement;
 export const errorMsg = document.getElementById("errorMsg") as HTMLDivElement;
+export const networkLockOverlay = document.getElementById("networkLockOverlay") as HTMLDivElement;
+export const networkLockMessage = document.getElementById("networkLockMessage") as HTMLParagraphElement;
 export const authSection = document.getElementById("authSection") as HTMLDivElement;
 export const togglePassword = document.getElementById("togglePassword") as HTMLButtonElement;
 export const savedSection = document.getElementById("savedSection") as HTMLDivElement;

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -141,6 +141,21 @@
       <div id="errorMsg" class="error-msg" style="display:none"></div>
     </div>
 
+    <div
+      id="networkLockOverlay"
+      class="network-lock-overlay"
+      hidden
+      aria-live="polite"
+      role="alertdialog"
+      aria-modal="true"
+      tabindex="-1"
+    >
+      <div class="network-lock-card">
+        <div class="network-lock-title">Cloakr is paused</div>
+        <p id="networkLockMessage" class="network-lock-message"></p>
+      </div>
+    </div>
+
     <script type="module" src="./main.ts"></script>
   </body>
 </html>

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -73,16 +73,71 @@ body * {
 
 body {
   width: 332px;
+  position: relative;
   background: var(--chrome-bg);
   color: var(--chrome-text);
   font-family: var(--font);
   font-size: 13px;
   line-height: 1.42;
+  overflow: hidden;
 }
 
 .app {
   display: flex;
   flex-direction: column;
+}
+
+body.is-network-locked .app {
+  filter: blur(7px) saturate(0.85);
+  pointer-events: none;
+  user-select: none;
+}
+
+.network-lock-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.58);
+  backdrop-filter: blur(14px) saturate(0.9);
+  -webkit-backdrop-filter: blur(14px) saturate(0.9);
+}
+
+.network-lock-overlay[hidden] {
+  display: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  .network-lock-overlay {
+    background: rgba(20, 22, 26, 0.58);
+  }
+}
+
+.network-lock-card {
+  width: 100%;
+  max-width: 280px;
+  padding: 18px 16px;
+  border-radius: 16px;
+  border: 1px solid var(--chrome-border);
+  background: color-mix(in srgb, var(--chrome-bg) 84%, transparent);
+  box-shadow: 0 18px 42px var(--chrome-shadow);
+  text-align: center;
+}
+
+.network-lock-title {
+  margin-bottom: 8px;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--chrome-text);
+}
+
+.network-lock-message {
+  color: var(--chrome-text-muted);
+  font-size: 12px;
+  line-height: 1.5;
 }
 
 .header {

--- a/entrypoints/shared/messages.ts
+++ b/entrypoints/shared/messages.ts
@@ -16,6 +16,7 @@ export type ProxyStatus = {
     host?: string;
     port?: number;
   } | null;
+  lockReason?: "external_proxy_active";
 };
 
 export type RuntimeErrorResponse = {


### PR DESCRIPTION
- Treat Cloakr as active only when its own proxy config is applied.
- Add external-proxy lock state for popup with blocking overlay message.
- Prevent proxy/auth conflicts with other extensions.
- Fix status synchronization and race conditions during proxy apply.
- Remove redundant UI state artifacts.
- Ensure Cloakr remains off until explicitly enabled by user.

Closes #1 